### PR TITLE
chart fix: render migration job altijd toggle via migrations.enabled

### DIFF
--- a/charts/datamigratie/README.md
+++ b/charts/datamigratie/README.md
@@ -39,6 +39,7 @@ A Helm chart for the Datamigratie Component
 | livenessProbe.periodSeconds | int | `10` |  |
 | livenessProbe.successThreshold | int | `1` |  |
 | livenessProbe.timeoutSeconds | int | `5` |  |
+| migrations.enabled | bool | `true` |  |
 | migrations.image.pullPolicy | string | `"IfNotPresent"` |  |
 | migrations.image.repository | string | `"ghcr.io/icatt-menselijk-digitaal/datamigratie-migrations"` |  |
 | migrations.image.tag | string | `""` |  |

--- a/charts/datamigratie/templates/migration-job.yaml
+++ b/charts/datamigratie/templates/migration-job.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.postgresql.enabled }}
+{{- if .Values.migrations.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -27,7 +27,7 @@ spec:
       - name: "{{ .Chart.Name }}-wait-for-postgresql"
         image: "ghcr.io/groundnuty/k8s-wait-for:v2.0"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        args: 
+        args:
         - "service"
         - "{{ .Release.Name }}-postgresql"
     {{- end }}

--- a/charts/datamigratie/values.yaml
+++ b/charts/datamigratie/values.yaml
@@ -6,6 +6,7 @@ image:
   tag: ""
 
 migrations:
+  enabled: true
   image:
     repository: "ghcr.io/icatt-menselijk-digitaal/datamigratie-migrations"
     pullPolicy: IfNotPresent


### PR DESCRIPTION
de migration job was gewrapped in postgresql.enabled waardoor migrations alleen draaiden bij de embedded bitnami postgres