### PR TITLE
DATA-698 add datamigratie kenmerk to all migrated zaken

### DIFF
--- a/Datamigratie.Common/Services/OpenZaak/Models/OzZaak.cs
+++ b/Datamigratie.Common/Services/OpenZaak/Models/OzZaak.cs
@@ -103,6 +103,9 @@ namespace Datamigratie.Common.Services.OpenZaak.Models
 
         [JsonPropertyName("startdatum")]
         public DateOnly Startdatum { get; set; }
+
+        [JsonPropertyName("kenmerken")]
+        public List<OzZaakKenmerk>? Kenmerken { get; set; }
     }
 
     public class OzValidationError

--- a/Datamigratie.Server/Features/MigrateZaken/ManageMigrations/StartMigration/Services/BuildMigrationQueueItemService.cs
+++ b/Datamigratie.Server/Features/MigrateZaken/ManageMigrations/StartMigration/Services/BuildMigrationQueueItemService.cs
@@ -1,8 +1,9 @@
-﻿using Datamigratie.Common.Config;
+﻿using System.Diagnostics;
+using System.Security.Cryptography;
+using Datamigratie.Common.Config;
 using Datamigratie.Common.Services.Det;
 using Datamigratie.Common.Services.Det.Models;
 using Datamigratie.Common.Services.OpenZaak.Models;
-using Microsoft.Extensions.Options;
 using Datamigratie.Data;
 using Datamigratie.Server.Features.MigrateZaken.ManageMigrations.StartMigration.Queues.Items;
 using Datamigratie.Server.Features.MigrateZaken.ManageMigrations.StartMigration.ValidateMappings.Besluittype;
@@ -17,6 +18,7 @@ using Datamigratie.Server.Features.MigrateZaken.ManageMigrations.StartMigration.
 using Datamigratie.Server.Features.MigrateZaken.MigrateZaak.Mappers;
 using Datamigratie.Server.Helpers;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 
 namespace Datamigratie.Server.Features.MigrateZaken.ManageMigrations.StartMigration.Services;
 
@@ -51,7 +53,7 @@ public class BuildMigrationQueueItemService(
         var ozZaaktypeUrl = new Uri($"{_openZaakBaseUrl}catalogi/api/v1/zaaktypen/{ozZaaktypeId}");
         var statusMapper = new StatusMapper(await GetStatusMappingsAsync(detZaaktype));
         var resultaatMapper = new ResultaatMapper(await GetResultaattypeMappingsAsync(detZaaktype));
-        var zaakMapper = new ZaakMapper(rsin, ozZaaktypeUrl, await GetVertrouwelijkheidMappingsAsync(detZaaktype));
+        var zaakMapper = new ZaakMapper(rsin, ozZaaktypeUrl, await GetVertrouwelijkheidMappingsAsync(detZaaktype), CreateDatamigratieKenmerk(detZaaktype.FunctioneleIdentificatie));
         var documentMapper = new DocumentMapper(
             rsin,
             await GetDocumentstatusMappingsAsync(),
@@ -158,5 +160,28 @@ public class BuildMigrationQueueItemService(
         var (isValid, mappings) = await validateRoltypeMappingsService.ValidateAndGetRoltypeMappings(detZaaktypeId);
         return isValid ? mappings
             : throw new InvalidOperationException("Not all DET rollen have been mapped to OZ roltypen. Please configure roltype mappings first.");
+    }
+
+    /// <summary>
+    /// Creates a new OzZaakKenmerk instance for data migration, using a SHA-1 hash of the specified functional
+    /// identifier.
+    /// </summary>
+    /// <remarks>The generated kenmerk is a hexadecimal string representation of the SHA-1 hash of the input
+    /// identifier. SHA-1 was chosen because it results in a 40 character hash, which is exactly the maximum length allowed for a kenmerk. The chance of a collision is extremely low.</remarks>
+    /// <param name="detZaaktypeFunctioneleIdentificatie">The functional identifier of the DET zaaktype to be hashed and used as the kenmerk value. Cannot be null.</param>
+    /// <returns>An OzZaakKenmerk object with the kenmerk set to the SHA-1 hash of the specified identifier and the bron set to
+    /// "Datamigratie".</returns>
+    public static OzZaakKenmerk CreateDatamigratieKenmerk(string detZaaktypeFunctioneleIdentificatie)
+    {
+        const int KenmerkMaxLength = 40;
+        var inputBytes = System.Text.Encoding.UTF8.GetBytes(detZaaktypeFunctioneleIdentificatie);
+        var hashBytes = SHA1.HashData(inputBytes);
+        var kenmerk = Convert.ToHexString(hashBytes);
+        Debug.Assert(kenmerk.Length <= KenmerkMaxLength);
+        return new OzZaakKenmerk
+        {
+            Kenmerk = kenmerk,
+            Bron = "Datamigratie"
+        };
     }
 }

--- a/Datamigratie.Server/Features/MigrateZaken/MigrateZaak/Mappers/ZaakMapper.cs
+++ b/Datamigratie.Server/Features/MigrateZaken/MigrateZaak/Mappers/ZaakMapper.cs
@@ -1,6 +1,4 @@
-﻿using System.Diagnostics;
-using System.Security.Cryptography;
-using Datamigratie.Common.Services.Det.Models;
+﻿using Datamigratie.Common.Services.Det.Models;
 using Datamigratie.Common.Services.OpenZaak.Models;
 using static Datamigratie.Server.Features.MigrateZaken.MigrateZaak.Mappers.StringTruncationHelper;
 

--- a/Datamigratie.Server/Features/MigrateZaken/MigrateZaak/Mappers/ZaakMapper.cs
+++ b/Datamigratie.Server/Features/MigrateZaken/MigrateZaak/Mappers/ZaakMapper.cs
@@ -1,10 +1,12 @@
-﻿using Datamigratie.Common.Services.Det.Models;
+﻿using System.Diagnostics;
+using System.Security.Cryptography;
+using Datamigratie.Common.Services.Det.Models;
 using Datamigratie.Common.Services.OpenZaak.Models;
 using static Datamigratie.Server.Features.MigrateZaken.MigrateZaak.Mappers.StringTruncationHelper;
 
 namespace Datamigratie.Server.Features.MigrateZaken.MigrateZaak.Mappers;
 
-public class ZaakMapper(string rsin, Uri ozZaaktypeUrl, Dictionary<bool, ZaakVertrouwelijkheidaanduiding> vertrouwelijkheidMappings)
+public class ZaakMapper(string rsin, Uri ozZaaktypeUrl, Dictionary<bool, ZaakVertrouwelijkheidaanduiding> vertrouwelijkheidMappings, OzZaakKenmerk datamigratieKenmerk)
 {
     public CreateOzZaakRequest Map(DetZaak detZaak)
     {
@@ -39,17 +41,15 @@ public class ZaakMapper(string rsin, Uri ozZaaktypeUrl, Dictionary<bool, ZaakVer
 
         var laatsteBetaaldatum = detZaak.Betaalgegevens?.TransactieDatum?.ToString("yyyy-MM-dd");
 
-        List<OzZaakKenmerk>? kenmerken = null;
+        List<OzZaakKenmerk> kenmerken = [datamigratieKenmerk];
+
         if (!string.IsNullOrWhiteSpace(detZaak.ExterneIdentificatie))
         {
-            kenmerken =
-            [
-                new OzZaakKenmerk
-                {
-                    Kenmerk = detZaak.ExterneIdentificatie,
-                    Bron = "e-Suite"
-                }
-            ];
+            kenmerken.Add(new OzZaakKenmerk
+            {
+                Kenmerk = detZaak.ExterneIdentificatie,
+                Bron = "e-Suite"
+            });
         }
 
         var vertrouwelijkheidaanduiding = vertrouwelijkheidMappings.TryGetValue(detZaak.Vertrouwelijk, out var v) ? v

--- a/Datamigratie.Server/Features/MigrateZaken/MigrateZaak/MigrateZaakService.cs
+++ b/Datamigratie.Server/Features/MigrateZaken/MigrateZaak/MigrateZaakService.cs
@@ -67,12 +67,17 @@ namespace Datamigratie.Server.Features.MigrateZaken.MigrateZaak
             {
                 var zaakRequest = mapping.ZaakMapper.Map(detZaak);
 
-
                 // Check if zaken with the same identificatie already exist in OpenZaak and delete all matches to allow re-run
                 var existingZaken = await _openZaakApiClient.GetZakenByIdentificatie(detZaak.FunctioneleIdentificatie);
                 foreach (var existingZaak in existingZaken)
                 {
-                    await DeleteExistingZaakAndRelatedObjectsAsync(existingZaak, token);
+                    // only delete if the kenmerken match (we add one for the zaak and one for the zaaktype)
+                    if (existingZaak.Kenmerken != null 
+                        && zaakRequest.Kenmerken != null 
+                        && existingZaak.Kenmerken.All(a => zaakRequest.Kenmerken.Any(b => a.Kenmerk == b.Kenmerk && a.Bron == b.Bron)))
+                    {
+                        await DeleteExistingZaakAndRelatedObjectsAsync(existingZaak, token);
+                    }
                 }
 
                 OzZaak createdZaak;

--- a/Datamigratie.Server/Features/MigrateZaken/MigrateZaak/MigrateZaakService.cs
+++ b/Datamigratie.Server/Features/MigrateZaken/MigrateZaak/MigrateZaakService.cs
@@ -71,10 +71,10 @@ namespace Datamigratie.Server.Features.MigrateZaken.MigrateZaak
                 var existingZaken = await _openZaakApiClient.GetZakenByIdentificatie(detZaak.FunctioneleIdentificatie);
                 foreach (var existingZaak in existingZaken)
                 {
-                    // only delete if the kenmerken match (we add one for the zaak and one for the zaaktype)
-                    if (existingZaak.Kenmerken != null 
-                        && zaakRequest.Kenmerken != null 
-                        && existingZaak.Kenmerken.All(a => zaakRequest.Kenmerken.Any(b => a.Kenmerk == b.Kenmerk && a.Bron == b.Bron)))
+                    // only delete if the existing zaak contains all kenmerken from the new request
+                    if (existingZaak.Kenmerken != null
+                        && zaakRequest.Kenmerken != null
+                        && zaakRequest.Kenmerken.All(a => existingZaak.Kenmerken.Any(b => a.Kenmerk == b.Kenmerk && a.Bron == b.Bron)))
                     {
                         await DeleteExistingZaakAndRelatedObjectsAsync(existingZaak, token);
                     }

--- a/Datamigratie.Tests/Server/Features/MigrateZaken/ManageMigrations/StartMigration/Services/BuildMigrationQueueItemTests.cs
+++ b/Datamigratie.Tests/Server/Features/MigrateZaken/ManageMigrations/StartMigration/Services/BuildMigrationQueueItemTests.cs
@@ -1,0 +1,40 @@
+﻿using Datamigratie.Server.Features.MigrateZaken.ManageMigrations.StartMigration.Services;
+
+namespace Datamigratie.Tests.Server.Features.MigrateZaken.ManageMigrations.StartMigration.Services;
+
+public class BuildMigrationQueueItemTests
+{
+    [Fact]
+    public void CreateDatamigratieKenmerk_SetsBronToDatamigratie()
+    {
+        var result = BuildMigrationQueueItemService.CreateDatamigratieKenmerk("ZK-001");
+
+        Assert.Equal("Datamigratie", result.Bron);
+    }
+
+    [Fact]
+    public void CreateDatamigratieKenmerk_KenmerkDoesNotExceed40Characters()
+    {
+        var result = BuildMigrationQueueItemService.CreateDatamigratieKenmerk("some-very-long-functional-identifier-that-exceeds-normal-length");
+
+        Assert.True(result.Kenmerk.Length <= 40);
+    }
+
+    [Fact]
+    public void CreateDatamigratieKenmerk_SameInputProducesSameOutput()
+    {
+        var result1 = BuildMigrationQueueItemService.CreateDatamigratieKenmerk("ZK-002");
+        var result2 = BuildMigrationQueueItemService.CreateDatamigratieKenmerk("ZK-002");
+
+        Assert.Equal(result1.Kenmerk, result2.Kenmerk);
+    }
+
+    [Fact]
+    public void CreateDatamigratieKenmerk_DifferentInputProducesDifferentOutput()
+    {
+        var result1 = BuildMigrationQueueItemService.CreateDatamigratieKenmerk("ZK-001");
+        var result2 = BuildMigrationQueueItemService.CreateDatamigratieKenmerk("ZK-002");
+
+        Assert.NotEqual(result1.Kenmerk, result2.Kenmerk);
+    }
+}

--- a/Datamigratie.Tests/Server/Features/MigrateZaken/ManageMigrations/StartMigration/Services/StartMigrationServiceTests.cs
+++ b/Datamigratie.Tests/Server/Features/MigrateZaken/ManageMigrations/StartMigration/Services/StartMigrationServiceTests.cs
@@ -38,7 +38,7 @@ public class StartMigrationServiceTests
             ZakenSelector = selector,
             ResultaatMapper = new ResultaatMapper(new Dictionary<string, Uri>()),
             StatusMapper = new StatusMapper(new Dictionary<string, Uri>()),
-            ZaakMapper = new ZaakMapper("000000000", new Uri("https://openzaak.test/catalogi/api/v1/zaaktypen/00000000-0000-0000-0000-000000000000"), new Dictionary<bool, ZaakVertrouwelijkheidaanduiding>()),
+            ZaakMapper = new ZaakMapper("000000000", new Uri("https://openzaak.test/catalogi/api/v1/zaaktypen/00000000-0000-0000-0000-000000000000"), new Dictionary<bool, ZaakVertrouwelijkheidaanduiding>(), new OzZaakKenmerk { Kenmerk = "test", Bron = "Datamigratie" }),
             DocumentMapper = new DocumentMapper(
                 "000000000",
                 new Dictionary<string, DocumentStatus>(),

--- a/Datamigratie.Tests/Server/Features/MigrateZaken/ManageMigrations/StartMigration/StartSingleMigration/StartSingleMigrationControllerTests.cs
+++ b/Datamigratie.Tests/Server/Features/MigrateZaken/ManageMigrations/StartMigration/StartSingleMigration/StartSingleMigrationControllerTests.cs
@@ -45,7 +45,7 @@ public class StartSingleMigrationControllerTests
         ZakenSelector = new SingleZaakSelector(Zaaknummer, open: false),
         ResultaatMapper = new ResultaatMapper([]),
         StatusMapper = new StatusMapper([]),
-        ZaakMapper = new ZaakMapper("000000000", new Uri("https://openzaak.test/catalogi/api/v1/zaaktypen/00000000-0000-0000-0000-000000000000"), []),
+        ZaakMapper = new ZaakMapper("000000000", new Uri("https://openzaak.test/catalogi/api/v1/zaaktypen/00000000-0000-0000-0000-000000000000"), [], new OzZaakKenmerk { Kenmerk = "test", Bron = "Datamigratie" }),
         DocumentMapper = new DocumentMapper(
             "000000000",
             [],

--- a/Datamigratie.Tests/Server/Features/MigrateZaken/MigrateZaak/Mappers/ZaakMapperTests.cs
+++ b/Datamigratie.Tests/Server/Features/MigrateZaken/MigrateZaak/Mappers/ZaakMapperTests.cs
@@ -81,7 +81,7 @@ public class ZaakMapperTests
     }
 
     [Fact]
-    public void Map_NoExterneIdentificatie_KenmerkenNull()
+    public void Map_NoExterneIdentificatie_SingleKenmerk()
     {
         var mapper = CreateMapper();
 

--- a/Datamigratie.Tests/Server/Features/MigrateZaken/MigrateZaak/Mappers/ZaakMapperTests.cs
+++ b/Datamigratie.Tests/Server/Features/MigrateZaken/MigrateZaak/Mappers/ZaakMapperTests.cs
@@ -12,13 +12,19 @@ public class ZaakMapperTests
 
     private static readonly Uri ZaaktypeUrl = new($"{OpenZaakBaseUrl}catalogi/api/v1/zaaktypen/{ZaaktypeId}");
 
+    private static readonly OzZaakKenmerk DatamigratieKenmerk = new()
+    {
+        Kenmerk = "test-kenmerk",
+        Bron = "Datamigratie"
+    };
+
     private static ZaakMapper CreateMapper(Dictionary<bool, ZaakVertrouwelijkheidaanduiding>? mappings = null)
     {
         return new ZaakMapper(Rsin, ZaaktypeUrl, mappings ?? new Dictionary<bool, ZaakVertrouwelijkheidaanduiding>
         {
             { false, ZaakVertrouwelijkheidaanduiding.openbaar },
             { true, ZaakVertrouwelijkheidaanduiding.vertrouwelijk }
-        });
+        }, DatamigratieKenmerk);
     }
 
     [Fact]
@@ -40,9 +46,11 @@ public class ZaakMapperTests
         Assert.Equal($"{OpenZaakBaseUrl}catalogi/api/v1/zaaktypen/{ZaaktypeId}", result.Zaaktype.ToString());
         Assert.Equal(ZaakVertrouwelijkheidaanduiding.openbaar, result.Vertrouwelijkheidaanduiding);
         Assert.NotNull(result.Kenmerken);
-        Assert.Single(result.Kenmerken);
-        Assert.Equal("EXT-001", result.Kenmerken[0].Kenmerk);
-        Assert.Equal("e-Suite", result.Kenmerken[0].Bron);
+        Assert.Equal(2, result.Kenmerken.Count);
+        Assert.Equal("test-kenmerk", result.Kenmerken[0].Kenmerk);
+        Assert.Equal("Datamigratie", result.Kenmerken[0].Bron);
+        Assert.Equal("EXT-001", result.Kenmerken[1].Kenmerk);
+        Assert.Equal("e-Suite", result.Kenmerken[1].Bron);
     }
 
     [Fact]
@@ -81,7 +89,10 @@ public class ZaakMapperTests
 
         var result = mapper.Map(detZaak);
 
-        Assert.Null(result.Kenmerken);
+        Assert.NotNull(result.Kenmerken);
+        Assert.Single(result.Kenmerken);
+        Assert.Equal("test-kenmerk", result.Kenmerken[0].Kenmerk);
+        Assert.Equal("Datamigratie", result.Kenmerken[0].Bron);
     }
 
     [Fact]

--- a/Datamigratie.Tests/Server/Features/MigrateZaken/MigrateZaak/MigrateRollenTests.cs
+++ b/Datamigratie.Tests/Server/Features/MigrateZaken/MigrateZaak/MigrateRollenTests.cs
@@ -96,7 +96,7 @@ public class MigrateRollenTests
             {
                 { false, ZaakVertrouwelijkheidaanduiding.openbaar },
                 { true, ZaakVertrouwelijkheidaanduiding.vertrouwelijk }
-            }),
+            }, new OzZaakKenmerk { Kenmerk = "test", Bron = "Datamigratie" }),
             BesluitMapper = new(rsin, []),
             PdfMapper = new(rsin, new Uri("https://example.com")),
             ResultaatMapper = new([]),
@@ -600,8 +600,8 @@ public class MigrateRollenTests
         var clientMock = CreateOpenZaakClientMock();
         clientMock.Setup(c => c.GetZakenByIdentificatie(It.IsAny<string>()))
             .ReturnsAsync([
-                new OzZaak { Url = zaakUrl1, Zaaktype = new Uri(ZaaktypeUrl) },
-                new OzZaak { Url = zaakUrl2, Zaaktype = new Uri(ZaaktypeUrl) }
+                new OzZaak { Url = zaakUrl1, Zaaktype = new Uri(ZaaktypeUrl), Kenmerken = [new OzZaakKenmerk { Kenmerk = "test", Bron = "Datamigratie" }] },
+                new OzZaak { Url = zaakUrl2, Zaaktype = new Uri(ZaaktypeUrl), Kenmerken = [new OzZaakKenmerk { Kenmerk = "test", Bron = "Datamigratie" }] }
             ]);
         clientMock.Setup(c => c.GetZaakInformatieobjectenForZaak(It.IsAny<Uri>()))
             .ReturnsAsync([]);

--- a/docs/changelog/changelog.md
+++ b/docs/changelog/changelog.md
@@ -2,6 +2,7 @@
 
 ## Current Version
 
+- [Safely delete zaken](https://dimpact.atlassian.net/browse/DATA-698)
 - [Migrate additional document property](https://dimpact.atlassian.net/browse/DATA-272)
 - [Implement UI changes](https://dimpact.atlassian.net/browse/DATA-256)
 - [Fix 1 hour maximum for migrations (JWT token related)](https://dimpact.atlassian.net/browse/DATA-194)


### PR DESCRIPTION
Introduce a SHA-1-based datamigratie kenmerk for every created zaak, ensuring traceability of migrated cases. Update ZaakMapper and OzZaak models to support and always include this kenmerk. Adjust deletion logic to match on kenmerken.