### PR TITLE
wacht op migration-job 

### DIFF
--- a/charts/datamigratie/templates/deployment.yaml
+++ b/charts/datamigratie/templates/deployment.yaml
@@ -34,12 +34,12 @@ spec:
       serviceAccountName: {{ include "datamigratie.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- if .Values.postgresql.enabled }}
+      {{- if .Values.migrations.enabled }}
       initContainers:
       - name: "{{ .Chart.Name }}-wait-for-migrations"
         image: "ghcr.io/groundnuty/k8s-wait-for:v2.0"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        args: 
+        args:
         - "job"
         - "{{ include "datamigratie.fullname" . }}-migrations-{{ .Release.Revision }}"
       {{- end }}


### PR DESCRIPTION
gewijzigd naar migrations.enabled zodat de app altijd op de migrations wacht zolang die aanstaan. migrations draaien daarmee automatisch bij deploy; de handmatige kubectl-run stap vervalt