### PR TITLE
fix(datamigratie): wait-for-migrations gebruikt job-wr i.p.v. job

### DIFF
--- a/charts/datamigratie/templates/deployment.yaml
+++ b/charts/datamigratie/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
         image: "{{ .Values.initContainers.waitFor.image.repository }}:{{ .Values.initContainers.waitFor.image.tag }}"
         imagePullPolicy: {{ .Values.initContainers.waitFor.image.pullPolicy }}
         args:
-        - "job"
+        - "job-wr"
         - "{{ include "datamigratie.fullname" . }}-migrations-{{ .Release.Revision }}"
       {{- end }}
       containers:


### PR DESCRIPTION
Zelfde bug als pabc: k8s-wait-for hangt in 'job'-mode op een migratie-job met een failed-poging in de historie (na drain/undrain), ook al is de job Complete. 'job-wr' tolereert failed-pogingen en wacht op minstens 1 succes. Losse release (eigen v0.3.x tag)