### PR TITLE
fix(datamigratie): wait-for-migrations job-wr i.p.v. job (main)

### DIFF
--- a/charts/datamigratie/templates/deployment.yaml
+++ b/charts/datamigratie/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
         image: "{{ .Values.initContainers.waitFor.image.repository }}:{{ .Values.initContainers.waitFor.image.tag }}"
         imagePullPolicy: {{ .Values.initContainers.waitFor.image.pullPolicy }}
         args:
-        - "job"
+        - "job-wr"
         - "{{ include "datamigratie.fullname" . }}-migrations-{{ .Release.Revision }}"
       {{- end }}
       containers:


### PR DESCRIPTION
Zelfde fix als #222 maar richting `main`, zodat toekomstige releases de `job-wr` wait-for behouden (#222 landt op `release-0.3.x` voor de v0.3.1 patch). 1 regel: `charts/datamigratie/templates/deployment.yaml` wait-for `job` -> `job-wr`.